### PR TITLE
Minor deployment improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,36 @@
-FROM rust:1.62-slim-buster as builder
+FROM rust:1.62-slim-buster AS builder
+ENV BUILD_DIR=/opt/xombie-build
+WORKDIR ${BUILD_DIR}
 
-RUN mkdir -p /opt/xombie-build
-COPY . /opt/xombie-build
-
-WORKDIR /opt/xombie-build
-
+# -- build from scratch
+COPY libs        ${BUILD_DIR}/libs
+COPY services    ${BUILD_DIR}/services
+COPY third_party ${BUILD_DIR}/third_party
+COPY tools       ${BUILD_DIR}/tools
+COPY Cargo.toml  ${BUILD_DIR}/Cargo.toml
+COPY Cargo.lock  ${BUILD_DIR}/Cargo.lock
 RUN cargo build --release
 
-FROM debian:buster-slim
+# -- or copy in pre-built binaries
+# RUN mkdir -p ${BUILD_DIR}/target
+# COPY target/release ${BUILD_DIR}/target/release
 
-# api
-EXPOSE 80
-# kdc
-EXPOSE 88/udp
-# faux_dns
-EXPOSE 5300/udp
-# sg
-EXPOSE 3074/udp
-
+FROM debian:buster-slim AS common
 RUN mkdir -p /opt/xombie/bin
 WORKDIR /opt/xombie
 
+FROM common AS api
+EXPOSE 80
 COPY --from=builder /opt/xombie-build/target/release/api /opt/xombie/bin/api
+
+FROM common AS kdc
+EXPOSE 88/udp
 COPY --from=builder /opt/xombie-build/target/release/kdc /opt/xombie/bin/kdc
+
+FROM common AS dns
+EXPOSE 5300/udp
 COPY --from=builder /opt/xombie-build/target/release/faux-dns /opt/xombie/bin/faux-dns
+
+FROM common AS sg
+EXPOSE 3074/udp
 COPY --from=builder /opt/xombie-build/target/release/sg /opt/xombie/bin/sg

--- a/README.md
+++ b/README.md
@@ -12,8 +12,23 @@ your own risk.**
 
 Running
 -------
+Install Docker with [Compose](https://github.com/docker/compose/releases). It's recommended to use BuildKit. For this,
+set these environment variables (e.g. in your .bashrc):
 
-```docker-compose up -d```
+```bash
+COMPOSE_DOCKER_CLI_BUILD=1
+DOCKER_BUILDKIT=1
+```
+
+When services are brought up for the first time, the database will be initialized from `db.sql`, which contains
+hardcoded service IP addresses and a test account. Importantly, check that the IP addresses match expected deployment
+configuration.
+
+Build and bring up services with:
+
+```bash
+docker compose up --build --detach
+```
 
 Notes:
 
@@ -34,3 +49,29 @@ Then write your own resolv.conf containing (for instance to use google's DNS
 servers)
 
 ```nameserver  8.8.8.8```
+
+Development
+-----------
+If you want to use containers for development, but also want incremental builds for a fast workflow, adjust `Dockerfile`
+to copy service binaries into place during image build instead of building from scratch. Check `.dockerignore` and make
+sure binaries aren't filtered. Then build locally or with another container:
+
+```bash
+docker run -it --rm -v $PWD:/work -w /work -eCARGO_HOME=/work/cargo rust:1.62-slim-buster cargo build --release
+```
+
+Testing with xemu
+-----------------
+You can easily create a test network experiment with [xemu](https://xemu.app).
+
+* Create a bridge:
+```bash
+sudo ip link add br0 type bridge
+sudo ip addr add 192.168.5.1/24 dev br0
+sudo ip link set br0 up
+```
+* Edit `docker-compose.yml` to bind to the bridge IP. e.g. replace `88:88/udp` with `192.168.5.1:88:88/udp`
+* Start services: `docker compose up --build` (we'll leave out `--detach` to see log messages)
+* You can check that the DNS server is responsive with: `dig @192.168.5.1 macs.xboxlive.com`
+* Start xemu, enable NAT networking (Settings > Machine > Network)
+* In Xbox dashboard, go to network settings and set DNS server to `192.168.5.1`

--- a/build-backend.sh
+++ b/build-backend.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-docker build -t xombie/userv .

--- a/db.sql
+++ b/db.sql
@@ -1,0 +1,201 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 14.0 (Debian 14.0-1.pgdg110+1)
+-- Dumped by pg_dump version 14.4
+
+-- Started on 2022-08-22 01:26:56 UTC
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- TOC entry 209 (class 1259 OID 16385)
+-- Name: client_keys; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.client_keys (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    xuid text NOT NULL,
+    kvno integer NOT NULL,
+    key text NOT NULL,
+    key_type text NOT NULL
+);
+
+
+ALTER TABLE public.client_keys OWNER TO postgres;
+
+--
+-- TOC entry 213 (class 1259 OID 16419)
+-- Name: clients; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.clients (
+    xuid text NOT NULL,
+    gamertag text NOT NULL
+);
+
+
+ALTER TABLE public.clients OWNER TO postgres;
+
+--
+-- TOC entry 210 (class 1259 OID 16396)
+-- Name: kdc_nodes; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.kdc_nodes (
+    external_ip inet NOT NULL
+);
+
+
+ALTER TABLE public.kdc_nodes OWNER TO postgres;
+
+--
+-- TOC entry 211 (class 1259 OID 16401)
+-- Name: machines; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.machines (
+    xuid text NOT NULL,
+    serial text NOT NULL,
+    macaddress macaddr NOT NULL
+);
+
+
+ALTER TABLE public.machines OWNER TO postgres;
+
+--
+-- TOC entry 212 (class 1259 OID 16406)
+-- Name: sg_nodes; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sg_nodes (
+    external_ip inet NOT NULL
+);
+
+
+ALTER TABLE public.sg_nodes OWNER TO postgres;
+
+--
+-- TOC entry 3332 (class 0 OID 16385)
+-- Dependencies: 209
+-- Data for Name: client_keys; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.client_keys (id, xuid, kvno, key, key_type) FROM stdin;
+af29ab1c-e87d-4b24-97f6-e2d9e3eb83c8	fedcba9876543210	1	F527C851590D42072D6925BC7037C21D	hdd_key
+e3cf66cd-08f1-47b6-ba74-b416c60f058b	fedcba9876543210	1	8CEEB50C43FE70FA378A9577B21FD8FE	online_key
+6db8ea20-ef01-484e-ba6e-6e78b6654c64	fedcba9876543210	1	BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB	client_master_key
+a7f49ce6-ae00-4020-9118-07c530c22c48	fedcba9876543210	1	BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB	tgs_client_session_key
+3eae2fe7-09ce-48f5-9317-7ac8be65d40c	fedcba9876543210	1	BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB	sg_service_session_key
+\.
+
+
+--
+-- TOC entry 3336 (class 0 OID 16419)
+-- Dependencies: 213
+-- Data for Name: clients; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.clients (xuid, gamertag) FROM stdin;
+fedcba9876543210	SN.631866003115
+\.
+
+
+--
+-- TOC entry 3333 (class 0 OID 16396)
+-- Dependencies: 210
+-- Data for Name: kdc_nodes; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.kdc_nodes (external_ip) FROM stdin;
+192.168.5.1
+\.
+
+
+--
+-- TOC entry 3334 (class 0 OID 16401)
+-- Dependencies: 211
+-- Data for Name: machines; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.machines (xuid, serial, macaddress) FROM stdin;
+fedcba9876543210	631866003115	00:50:f2:ec:6a:aa
+\.
+
+
+--
+-- TOC entry 3335 (class 0 OID 16406)
+-- Dependencies: 212
+-- Data for Name: sg_nodes; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.sg_nodes (external_ip) FROM stdin;
+192.168.5.1
+\.
+
+
+--
+-- TOC entry 3184 (class 2606 OID 16412)
+-- Name: client_keys client_keys_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.client_keys
+    ADD CONSTRAINT client_keys_pkey PRIMARY KEY (id);
+
+
+--
+-- TOC entry 3192 (class 2606 OID 16425)
+-- Name: clients clients_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.clients
+    ADD CONSTRAINT clients_pkey PRIMARY KEY (xuid);
+
+
+--
+-- TOC entry 3186 (class 2606 OID 16414)
+-- Name: kdc_nodes kdc_nodes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.kdc_nodes
+    ADD CONSTRAINT kdc_nodes_pkey PRIMARY KEY (external_ip);
+
+
+--
+-- TOC entry 3188 (class 2606 OID 16416)
+-- Name: machines machines_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.machines
+    ADD CONSTRAINT machines_pkey PRIMARY KEY (xuid);
+
+
+--
+-- TOC entry 3190 (class 2606 OID 16418)
+-- Name: sg_nodes sg_nodes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sg_nodes
+    ADD CONSTRAINT sg_nodes_pkey PRIMARY KEY (external_ip);
+
+
+-- Completed on 2022-08-22 01:26:56 UTC
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3"
 
 services:
     api:
-        image: xombie/userv
+        build:
+            context: .
+            target: api
         command: /opt/xombie/bin/api
         networks:
             - frontend
@@ -11,8 +13,10 @@ services:
             - db
             - redis
 
-    faux_dns:
-        image: xombie/userv
+    dns:
+        build:
+            context: .
+            target: dns
         command: /opt/xombie/bin/faux-dns --dns-port 5300
         ports:
             - "53:5300/udp"
@@ -24,7 +28,9 @@ services:
             - redis
     
     kdc:
-        image: xombie/userv
+        build:
+            context: .
+            target: kdc
         command: /opt/xombie/bin/kdc
         ports:
             - "88:88/udp"
@@ -36,7 +42,9 @@ services:
             - redis
     
     sg:
-        image: xombie/userv
+        build:
+            context: .
+            target: sg
         command: /opt/xombie/bin/sg
         ports:
             - "3074:3074/udp"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,9 +76,12 @@ services:
         image: postgres:14.0
         environment:
             POSTGRES_USER: "postgres"
+            POSTGRES_PASSWORD: "postgres"
+            POSTGRES_DB: "xombie"
         volumes:
             - "db-data:/var/lib/postgresql/data"
             - "./healthchecks:/healthchecks"
+            - ./db.sql:/docker-entrypoint-initdb.d/db.sql
         healthcheck:
             test: /healthchecks/postgres.sh
             interval: "5s"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,21 @@ services:
             - backend
         restart: always
 
+    # pgadmin:
+    #     image: dpage/pgadmin4
+    #     environment:
+    #         PGPASSWORD: "postgres"
+    #         PGADMIN_DEFAULT_EMAIL: "admin@xombie.org"
+    #         PGADMIN_DEFAULT_PASSWORD: "xombie"
+    #     ports:
+    #         - "9443:443"
+    #         - "9080:80"
+    #     networks:
+    #         - backend
+    #     volumes:
+    #         - ./pgadmin-servers.json:/pgadmin4/servers.json
+    #         - ./pgadmin-pgpass:/pgadmin4/pgpass
+
     nginx:
         build:
             context: frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         depends_on:
             - db
             - redis
+        restart: always
 
     dns:
         build:
@@ -26,6 +27,7 @@ services:
         depends_on:
             - db
             - redis
+        restart: always
     
     kdc:
         build:
@@ -40,6 +42,7 @@ services:
         depends_on:
             - db
             - redis
+        restart: always
     
     sg:
         build:
@@ -54,6 +57,7 @@ services:
         depends_on:
             - db
             - redis
+        restart: always
     
     redis:
         image: redis:6.2.5-alpine
@@ -66,6 +70,7 @@ services:
             - "6379:6379"
         networks:
             - backend
+        restart: always
 
     db:
         image: postgres:14.0
@@ -81,6 +86,7 @@ services:
             - "5432:5432"
         networks:
             - backend
+        restart: always
 
     nginx:
         build:
@@ -96,6 +102,7 @@ services:
             - frontend
         depends_on:
             - api
+        restart: always
 
 volumes:
     db-data:

--- a/pgadmin-pgpass
+++ b/pgadmin-pgpass
@@ -1,0 +1,1 @@
+db:5432:xombie:postgres:postgres

--- a/pgadmin-servers.json
+++ b/pgadmin-servers.json
@@ -1,0 +1,19 @@
+{
+    "Servers": {
+        "1": {
+            "Name": "xombie",
+            "Group": "Servers",
+            "Host": "db",
+            "Port": 5432,
+            "MaintenanceDB": "postgres",
+            "Username": "postgres",
+            "PassFile": "/pgpass",
+            "SSLMode": "prefer",
+            "SSLCompression": 0,
+            "Timeout": 10,
+            "UseSSHTunnel": 0,
+            "TunnelPort": "22",
+            "TunnelAuthentication": 0
+        }
+    }
+}


### PR DESCRIPTION
Thanks for sharing this project! I was able to stand up an instance and pass the Xbox Dashboard settings menu Xbox Live connection test with it using xemu; although some minor code changes were required to do this on my end, and I'll mark those changes as issues on the repo.

* Separates each service into a separate container image
* Adds a service restart policy
* Adds initial database setup, with a sample account and hard-coded cluster addresses
  * Kudos to @GXTX for [sharing their initial script](https://github.com/XombieOnline/xombie/issues/2#issuecomment-1221333778)
* Adds a pgadmin service
* Adds some notes to the README regarding the above